### PR TITLE
Medical schema

### DIFF
--- a/schema_based_on_diagram.sql
+++ b/schema_based_on_diagram.sql
@@ -1,42 +1,42 @@
 CREATE TABLE patients (
-    id BIGSERIAL PRIMARY KEY,
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name VARCHAR(100) NOT NULL,
     date_of_birth DATE NOT NULL
-)
+);
 
 CREATE TABLE medical_histories (
-    id BIGSERIAL PRIMARY KEY,
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     admitted_at TIMESTAMP NOT NULL,
     status VARCHAR(100) NOT NULL,
     patient_id BIGINT NOT NULL,
     FOREIGN KEY (patient_id) REFERENCES patients (id)
-)
+);
 
 CREATE TABLE treatments (
-    id BIGSERIAL PRIMARY KEY,
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     type VARCHAR(100) NOT NULL,
-    name VARCHAR(100) NOT NULL,
-)
+    name VARCHAR(100) NOT NULL
+);
 
 CREATE TABLE medical_treatments (
     treatment_id BIGINT NOT NULL,
     medical_histories_id BIGINT NOT NULL,
     FOREIGN KEY (treatment_id) REFERENCES treatments (id),
-    FOREIGN KEY (medical_histories_id) REFERENCES medical_histories (id)
+    FOREIGN KEY (medical_histories_id) REFERENCES medical_histories (id),
     PRIMARY KEY (treatment_id, medical_histories_id)
-)
+);
 
 CREATE TABLE invoices (
-    id BIGSERIAL PRIMARY KEY,
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     total_amount DECIMAL(10, 2) NOT NULL,
     generated_at TIMESTAMP NOT NULL,
     paid_at TIMESTAMP NOT NULL,
     medical_history_id INT UNIQUE,
     FOREIGN KEY (medical_history_id) REFERENCES medical_histories (id)
-)
+);
 
 CREATE TABLE invoice_items (
-    id GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     unit_price DECIMAL(10, 2) NOT NULL,
     quantity INT NOT NULL,
     total_price DECIMAL(10, 2) NOT NULL,
@@ -44,4 +44,4 @@ CREATE TABLE invoice_items (
     treatment_id BIGINT NOT NULL,
     FOREIGN KEY (invoice_id) REFERENCES invoices (id),
     FOREIGN KEY (treatment_id) REFERENCES treatments (id)
-)
+);

--- a/schema_based_on_diagram.sql
+++ b/schema_based_on_diagram.sql
@@ -45,3 +45,12 @@ CREATE TABLE invoice_items (
     FOREIGN KEY (invoice_id) REFERENCES invoices (id),
     FOREIGN KEY (treatment_id) REFERENCES treatments (id)
 );
+CREATE INDEX patient_id_index ON medical_histories(patient_id);
+CREATE INDEX medical_histories_id_index ON medical_treatments(medical_histories_id);
+CREATE INDEX treatment_id_index ON medical_treatments(treatment_id);
+CREATE INDEX invoice_id_index ON invoice_items(invoice_id);
+CREATE INDEX medical_history_id_index ON invoices(medical_history_id);
+CREATE INDEX treatment_id_index_2 ON invoice_items(treatment_id);
+
+
+

--- a/schema_based_on_diagram.sql
+++ b/schema_based_on_diagram.sql
@@ -1,0 +1,47 @@
+CREATE TABLE patients (
+    id BIGSERIAL PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    date_of_birth DATE NOT NULL
+)
+
+CREATE TABLE medical_histories (
+    id BIGSERIAL PRIMARY KEY,
+    admitted_at TIMESTAMP NOT NULL,
+    status VARCHAR(100) NOT NULL,
+    patient_id BIGINT NOT NULL,
+    FOREIGN KEY (patient_id) REFERENCES patients (id)
+)
+
+CREATE TABLE treatments (
+    id BIGSERIAL PRIMARY KEY,
+    type VARCHAR(100) NOT NULL,
+    name VARCHAR(100) NOT NULL,
+)
+
+CREATE TABLE medical_treatments (
+    treatment_id BIGINT NOT NULL,
+    medical_histories_id BIGINT NOT NULL,
+    FOREIGN KEY (treatment_id) REFERENCES treatments (id),
+    FOREIGN KEY (medical_histories_id) REFERENCES medical_histories (id)
+    PRIMARY KEY (treatment_id, medical_histories_id)
+)
+
+CREATE TABLE invoices (
+    id BIGSERIAL PRIMARY KEY,
+    total_amount DECIMAL(10, 2) NOT NULL,
+    generated_at TIMESTAMP NOT NULL,
+    paid_at TIMESTAMP NOT NULL,
+    medical_history_id INT UNIQUE,
+    FOREIGN KEY (medical_history_id) REFERENCES medical_histories (id)
+)
+
+CREATE TABLE invoice_items (
+    id GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    unit_price DECIMAL(10, 2) NOT NULL,
+    quantity INT NOT NULL,
+    total_price DECIMAL(10, 2) NOT NULL,
+    invoice_id BIGINT NOT NULL,
+    treatment_id BIGINT NOT NULL,
+    FOREIGN KEY (invoice_id) REFERENCES invoices (id),
+    FOREIGN KEY (treatment_id) REFERENCES treatments (id)
+)


### PR DESCRIPTION
Hello, dear code reviewer,

In this project, we added the following tables

Patients
Medical_histories
Treatments
Invoices
Invoice_items
medical_treatment (which is a many-to-many middle relation table, between "medical_histories" and "treatments")

![1b707565-37a7-4e8a-b307-2e86b25e40c1](https://user-images.githubusercontent.com/99001924/202035879-9dea3744-a3a2-43d5-8791-564c900558ab.jpg)


And:
Provided the appropriate links between tables with foreign keys

Finally, We created indexes for all foreign keys using these commands to improve the execution time performance for queries.
- CREATE INDEX patient_id_index ON medical_histories(patient_id);
- CREATE INDEX medical_histories_id_index ON medical_treatments(medical_histories_id);
- CREATE INDEX treatment_id_index ON medical_treatments(treatment_id);
- CREATE INDEX invoice_id_index ON invoice_items(invoice_id);
- CREATE INDEX medical_history_id_index ON invoices(medical_history_id);
- CREATE INDEX treatment_id_index_2 ON invoice_items(treatment_id); 
